### PR TITLE
chore: add workflow_dispatch trigger in issue-comment-json

### DIFF
--- a/.github/workflows/issue-comment-json.yaml
+++ b/.github/workflows/issue-comment-json.yaml
@@ -3,6 +3,7 @@ name: comment on a issue and get json
 on:
   issues:
     types: [opened]
+  workflow_dispatch: {}
 
 jobs:
   comment-with-action:


### PR DESCRIPTION
# Description
This pull reques adds the workflow_dispatch trigger in the issue-comment-json workflow to provided the execute the workflow manually through actions section on github actions