### PR TITLE
chore: update `production.yaml` workflow

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -6,8 +6,13 @@ on:
       - beta
 
 jobs:
+  json:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ toJson(github) }}"
+
   deploy:
-    if: startsWith(github.head_ref, 'release/')
+    if: startsWith(github.ref_name, 'release/')
     runs-on: ubuntu-latest
     environment: production
     steps:


### PR DESCRIPTION
This pr updates the production.yaml workflow which removed the github.base_ref property to compare if the source branch starts with release/ string, however the github.base_ref only works with pull_request triggeer